### PR TITLE
Fix compile errors: error: unable to find string literal operator 'operator""opt' with 'const char [4]', 'long unsigned int' arguments

### DIFF
--- a/x265/source/common/param.cpp
+++ b/x265/source/common/param.cpp
@@ -1396,7 +1396,7 @@ char *x265_param2string(x265_param* p)
         return NULL;
 
 #define BOOL(param, cliopt) \
-    s += sprintf(s, " %s", (param) ? cliopt : "no-"cliopt);
+    s += sprintf(s, " %s", (param) ? cliopt : "no-" cliopt);
 
     s += sprintf(s, "%dx%d", p->sourceWidth,p->sourceHeight);
     s += sprintf(s, " fps=%u/%u", p->fpsNum, p->fpsDenom);

--- a/x265/source/encoder/ratecontrol.cpp
+++ b/x265/source/encoder/ratecontrol.cpp
@@ -49,7 +49,7 @@ namespace {
 {\
     bErr = 0;\
     p = strstr(opts, opt "=");\
-    char* q = strstr(opts, "no-"opt);\
+    char* q = strstr(opts, "no-" opt);\
     if (p && sscanf(p, opt "=%d" , &i) && param_val != i)\
         bErr = 1;\
     else if (!param_val && !q && !p)\


### PR DESCRIPTION
Minor fixes of build failures like:

```
[ 38%] Building CXX object encoder/CMakeFiles/encoder.dir/ratecontrol.cpp.o
/home/pasha/SOFT/_SEPARATE_PACKAGES.rpm/libbpg/libbpg-0.9.7/x265/source/encoder/ratecontrol.cpp: In member function 'bool x265_12bit::RateControl::init(const x265_12bit::SPS&)':
/home/pasha/SOFT/_SEPARATE_PACKAGES.rpm/libbpg/libbpg-0.9.7/x265/source/encoder/ratecontrol.cpp:52:28: error: unable to find string literal operator 'operator""opt' with 'const char [4]', 'long unsigned int' arguments
     char* q = strstr(opts, "no-"opt);\
                            ^
/home/pasha/SOFT/_SEPARATE_PACKAGES.rpm/libbpg/libbpg-0.9.7/x265/source/encoder/ratecontrol.cpp:451:17: note: in expansion of macro 'CMP_OPT_FIRST_PASS'
                 CMP_OPT_FIRST_PASS("bitdepth", m_param->internalBitDepth);
                 ^~~~~~~~~~~~~~~~~~
/home/pasha/SOFT/_SEPARATE_PACKAGES.rpm/libbpg/libbpg-0.9.7/x265/source/encoder/ratecontrol.cpp:52:28: error: unable to find string literal operator 'operator""opt' with 'const char [4]', 'long unsigned int' arguments
     char* q = strstr(opts, "no-"opt);\
```

Full fail log: https://kojipkgs.fedoraproject.org//work/tasks/189/15270189/build.log
With fix it successive: http://koji.fedoraproject.org/koji/taskinfo?taskID=15270197
